### PR TITLE
Fix `#paren-expression` include

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -22,7 +22,7 @@
 					"include": "#node"
 				},
 				{
-					"include": "#parent-expression"
+					"include": "#paren-expression"
 				},
 				{
 					"include": "#bracket-expression"


### PR DESCRIPTION
Removed `t` in `parent` => `paren`

![image](https://github.com/user-attachments/assets/0f5a47fe-c688-4a22-a454-d014b4715325)
