### PR TITLE
Change `comment` to single `;`

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -30,7 +30,7 @@
 			]
 		},
 		"comment": {
-			"begin": ";;",
+			"begin": ";",
 			"beginCaptures": {
 				"0": {
 					"name": "comment.line.scm"


### PR DESCRIPTION
Comments only need a single semicolon `;`

Changed `;;` => `;`

https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/query.c#L378