### PR TITLE
Fix `@capture`

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -91,7 +91,7 @@
 			"patterns": [
 				{
 					"name": "variable.other.readwrite.scm",
-					"match": "\\@[a-zA-Z_.]+"
+					"match": "@[a-zA-Z0-9_.!?-]+"
 				}
 			]
 		},


### PR DESCRIPTION
Fixes #5

`@capture` supports all these characters: `a-zA-Z0-9_.!?-`

https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/query.c#L396-L407