### PR TITLE
Support full range of `field` syntax

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -82,8 +82,18 @@
 		"field": {
 			"patterns": [
 				{
-					"name": "entity.name.scm",
-					"match": "[a-zA-Z_]+:"
+					"name": "entity.name.type.scm",
+					"match": "[a-zA-Z0-9_.!?-]+:"
+				},
+				{
+					"name": "entity.name.type.negated.scm",
+					"begin": "!",
+					"end": "(?<=[a-zA-Z0-9_.!?-])(?![a-zA-Z0-9_.!?-])|(?=[^\\sa-zA-Z0-9_.!?-])",
+					"patterns": [
+						{
+							"include": "#comment"
+						}
+					]
 				}
 			]
 		},


### PR DESCRIPTION
Adds negated `!fields`
including their skip whitespace/comments feature

Adds all characters to normal positive `fields:`

https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/query.c#L2387-L2395