### PR TITLE
Include all `node` characters

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -99,7 +99,7 @@
 			"patterns": [
 				{
 					"name": "node.scm",
-					"match": "[a-zA-Z_]+"
+					"match": "[a-zA-Z0-9_.!?-]+"
 				}
 			]
 		}


### PR DESCRIPTION
`node` can support all the following characters `[a-zA-Z0-9_.!?-]`

https://github.com/tree-sitter/tree-sitter/blob/master/lib/src/query.c#L396-L407