### PR TITLE
Allow ` tsqnb` file extension, not just literal ` tsqnb` filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
                 "displayName": "Tree-Sitter Query",
                 "selector": [
                     {
-                        "filenamePattern": "tsqnb"
+                        "filenamePattern": "*.tsqnb"
                     }
                 ]
             }


### PR DESCRIPTION
Currently, the notebooks for this extension are only recognized if the file name is exactly `tsqnb` ([original commit](https://github.com/jrieken/vscode-tree-sitter-query/pull/1/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45) ).

This feature request allows a `tsqnb` file extension ( `*.tsqnb`).