### PR TITLE
feat(syntax): expand textmate grammar

### DIFF
--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -1,226 +1,226 @@
 {
-	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "Tree-sitter Query",
-	"scopeName": "source.scm",
-	"patterns": [
-		{
-			"include": "#expression"
-		}
-	],
-	"repository": {
-		"expression": {
-			"patterns": [
-				{ "include": "#comment-inherits" },
-				{ "include": "#comment-extends" },
-				{ "include": "#comment-format-ignore" },
-				{ "include": "#comment" },
-				{ "include": "#regex-predicate-call" },
-				{ "include": "#set-predicate-call" },
-				{ "include": "#predicate-call" },
-				{ "include": "#paren-expression" },
-				{ "include": "#bracket-expression" },
-				{ "include": "#string" },
-				{ "include": "#missing-keyword" },
-				{ "include": "#wildcard" },
-				{ "include": "#anchor" },
-				{ "include": "#capture" },
-				{ "include": "#quantifier" },
-				{ "include": "#negated-field" },
-				{ "include": "#field" },
-				{ "include": "#node" }
-			]
-		},
-		"comment-inherits": {
-			"match": "^\\s*(;+\\s*inherits\\s*:.*)$",
-			"captures": {
-				"1": { "name": "keyword.control.import.scm" }
-			}
-		},
-		"comment-extends": {
-			"match": "^\\s*(;+\\s*extends\\s*)$",
-			"captures": {
-				"1": { "name": "keyword.control.directive.scm" }
-			}
-		},
-		"comment-format-ignore": {
-			"match": "^\\s*(;+\\s*format-ignore\\s*)$",
-			"captures": {
-				"1": { "name": "keyword.control.directive.scm" }
-			}
-		},
-		"comment": {
-			"begin": ";",
-			"end": "$",
-			"name": "comment.line.semicolon.scm",
-			"beginCaptures": {
-				"0": { "name": "punctuation.definition.comment.scm" }
-			}
-		},
-		"string": {
-			"begin": "\"",
-			"end": "\"",
-			"name": "string.quoted.double.scm",
-			"beginCaptures": {
-				"0": { "name": "punctuation.definition.string.begin.scm" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.definition.string.end.scm" }
-			},
-			"patterns": [
-				{ "include": "#escape-sequence" }
-			]
-		},
-		"regex-string": {
-			"begin": "\"",
-			"end": "\"",
-			"name": "string.regexp.scm",
-			"beginCaptures": {
-				"0": { "name": "punctuation.definition.string.begin.scm" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.definition.string.end.scm" }
-			},
-			"patterns": [
-				{ "include": "#escape-sequence" }
-			]
-		},
-		"escape-sequence": {
-			"match": "\\\\(.|$)",
-			"name": "constant.character.escape.scm"
-		},
-		"regex-predicate-call": {
-			"begin": "(\\()\\s*(#)((?:not-)?(?:match|vim-match|lua-match|gsub)\\??)",
-			"beginCaptures": {
-				"1": { "name": "punctuation.section.parens.begin.scm" },
-				"2": { "name": "punctuation.definition.predicate.scm" },
-				"3": { "name": "entity.name.function.predicate.scm" }
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": { "name": "punctuation.section.parens.end.scm" }
-			},
-			"patterns": [
-				{ "include": "#capture" },
-				{ "include": "#regex-string" }
-			]
-		},
-		"set-predicate-call": {
-			"begin": "(\\()\\s*(#)(set!)",
-			"beginCaptures": {
-				"1": { "name": "punctuation.section.parens.begin.scm" },
-				"2": { "name": "punctuation.definition.predicate.scm" },
-				"3": { "name": "entity.name.function.predicate.scm" }
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": { "name": "punctuation.section.parens.end.scm" }
-			},
-			"patterns": [
-				{ "include": "#capture" },
-				{ "include": "#string" },
-				{ "include": "#predicate-number" },
-				{ "include": "#predicate-property" }
-			]
-		},
-		"predicate-call": {
-			"begin": "(\\()\\s*(#)([a-zA-Z_][a-zA-Z0-9_-]*)([?!]?)",
-			"beginCaptures": {
-				"1": { "name": "punctuation.section.parens.begin.scm" },
-				"2": { "name": "punctuation.definition.predicate.scm" },
-				"3": { "name": "entity.name.function.predicate.scm" },
-				"4": { "name": "punctuation.definition.predicate-type.scm" }
-			},
-			"end": "\\)",
-			"endCaptures": {
-				"0": { "name": "punctuation.section.parens.end.scm" }
-			},
-			"patterns": [
-				{ "include": "#capture" },
-				{ "include": "#string" },
-				{ "include": "#predicate-number" },
-				{ "include": "#predicate-identifier" }
-			]
-		},
-		"predicate-number": {
-			"match": "(?<!\\w)[-+]?[0-9]+(?:\\.[0-9]+)?(?!\\w)",
-			"name": "constant.numeric.scm"
-		},
-		"predicate-property": {
-			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
-			"name": "variable.other.property.scm"
-		},
-		"predicate-identifier": {
-			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
-			"name": "variable.parameter.scm"
-		},
-		"paren-expression": {
-			"begin": "\\(",
-			"end": "\\)",
-			"beginCaptures": {
-				"0": { "name": "punctuation.section.parens.begin.scm" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.section.parens.end.scm" }
-			},
-			"name": "meta.expression.group.scm",
-			"patterns": [
-				{ "include": "#expression" }
-			]
-		},
-		"bracket-expression": {
-			"begin": "\\[",
-			"end": "\\]",
-			"beginCaptures": {
-				"0": { "name": "punctuation.section.brackets.begin.scm" }
-			},
-			"endCaptures": {
-				"0": { "name": "punctuation.section.brackets.end.scm" }
-			},
-			"name": "meta.expression.alternative.scm",
-			"patterns": [
-				{ "include": "#expression" }
-			]
-		},
-		"missing-keyword": {
-			"match": "\\bMISSING\\b",
-			"name": "keyword.control.missing.scm"
-		},
-		"wildcard": {
-			"match": "\\b_\\b",
-			"name": "constant.language.wildcard.scm"
-		},
-		"anchor": {
-			"match": "(?<!\\w)\\.(?!\\w)",
-			"name": "keyword.operator.anchor.scm"
-		},
-		"capture": {
-			"match": "(@)([a-zA-Z_][a-zA-Z0-9_.]*)",
-			"captures": {
-				"1": { "name": "punctuation.definition.capture.scm" },
-				"2": { "name": "entity.name.type.capture.scm" }
-			}
-		},
-		"quantifier": {
-			"match": "[?*+]",
-			"name": "keyword.operator.quantifier.scm"
-		},
-		"negated-field": {
-			"match": "(!)([a-zA-Z_][a-zA-Z0-9_-]*)",
-			"captures": {
-				"1": { "name": "keyword.operator.negation.scm" },
-				"2": { "name": "variable.other.property.scm" }
-			}
-		},
-		"field": {
-			"match": "([a-zA-Z_][a-zA-Z0-9_-]*)(:)",
-			"captures": {
-				"1": { "name": "variable.other.member.scm" },
-				"2": { "name": "punctuation.separator.field.scm" }
-			}
-		},
-		"node": {
-			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
-			"name": "variable.other.node.scm"
-		}
-	}
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "Tree-sitter Query",
+  "scopeName": "source.scm",
+  "patterns": [
+    {
+      "include": "#expression"
+    }
+  ],
+  "repository": {
+    "expression": {
+      "patterns": [
+        { "include": "#comment-inherits" },
+        { "include": "#comment-extends" },
+        { "include": "#comment-format-ignore" },
+        { "include": "#comment" },
+        { "include": "#regex-predicate-call" },
+        { "include": "#set-predicate-call" },
+        { "include": "#predicate-call" },
+        { "include": "#paren-expression" },
+        { "include": "#bracket-expression" },
+        { "include": "#string" },
+        { "include": "#missing-keyword" },
+        { "include": "#wildcard" },
+        { "include": "#anchor" },
+        { "include": "#capture" },
+        { "include": "#quantifier" },
+        { "include": "#negated-field" },
+        { "include": "#field" },
+        { "include": "#node" }
+      ]
+    },
+    "comment-inherits": {
+      "match": "^\\s*(;+\\s*inherits\\s*:.*)$",
+      "captures": {
+        "1": { "name": "keyword.control.import.scm" }
+      }
+    },
+    "comment-extends": {
+      "match": "^\\s*(;+\\s*extends\\s*)$",
+      "captures": {
+        "1": { "name": "keyword.control.directive.scm" }
+      }
+    },
+    "comment-format-ignore": {
+      "match": "^\\s*(;+\\s*format-ignore\\s*)$",
+      "captures": {
+        "1": { "name": "keyword.control.directive.scm" }
+      }
+    },
+    "comment": {
+      "begin": ";",
+      "end": "$",
+      "name": "comment.line.semicolon.scm",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.comment.scm" }
+      }
+    },
+    "string": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.quoted.double.scm",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.scm" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.scm" }
+      },
+      "patterns": [
+        { "include": "#escape-sequence" }
+      ]
+    },
+    "regex-string": {
+      "begin": "\"",
+      "end": "\"",
+      "name": "string.regexp.scm",
+      "beginCaptures": {
+        "0": { "name": "punctuation.definition.string.begin.scm" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.definition.string.end.scm" }
+      },
+      "patterns": [
+        { "include": "#escape-sequence" }
+      ]
+    },
+    "escape-sequence": {
+      "match": "\\\\(.|$)",
+      "name": "constant.character.escape.scm"
+    },
+    "regex-predicate-call": {
+      "begin": "(\\()\\s*(#)((?:not-)?(?:match|vim-match|lua-match|gsub)\\??)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.section.parens.begin.scm" },
+        "2": { "name": "punctuation.definition.predicate.scm" },
+        "3": { "name": "entity.name.function.predicate.scm" }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": { "name": "punctuation.section.parens.end.scm" }
+      },
+      "patterns": [
+        { "include": "#capture" },
+        { "include": "#regex-string" }
+      ]
+    },
+    "set-predicate-call": {
+      "begin": "(\\()\\s*(#)(set!)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.section.parens.begin.scm" },
+        "2": { "name": "punctuation.definition.predicate.scm" },
+        "3": { "name": "entity.name.function.predicate.scm" }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": { "name": "punctuation.section.parens.end.scm" }
+      },
+      "patterns": [
+        { "include": "#capture" },
+        { "include": "#string" },
+        { "include": "#predicate-number" },
+        { "include": "#predicate-property" }
+      ]
+    },
+    "predicate-call": {
+      "begin": "(\\()\\s*(#)([a-zA-Z_][a-zA-Z0-9_-]*)([?!]?)",
+      "beginCaptures": {
+        "1": { "name": "punctuation.section.parens.begin.scm" },
+        "2": { "name": "punctuation.definition.predicate.scm" },
+        "3": { "name": "entity.name.function.predicate.scm" },
+        "4": { "name": "punctuation.definition.predicate-type.scm" }
+      },
+      "end": "\\)",
+      "endCaptures": {
+        "0": { "name": "punctuation.section.parens.end.scm" }
+      },
+      "patterns": [
+        { "include": "#capture" },
+        { "include": "#string" },
+        { "include": "#predicate-number" },
+        { "include": "#predicate-identifier" }
+      ]
+    },
+    "predicate-number": {
+      "match": "(?<!\\w)[-+]?[0-9]+(?:\\.[0-9]+)?(?!\\w)",
+      "name": "constant.numeric.scm"
+    },
+    "predicate-property": {
+      "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+      "name": "variable.other.property.scm"
+    },
+    "predicate-identifier": {
+      "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+      "name": "variable.parameter.scm"
+    },
+    "paren-expression": {
+      "begin": "\\(",
+      "end": "\\)",
+      "beginCaptures": {
+        "0": { "name": "punctuation.section.parens.begin.scm" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.section.parens.end.scm" }
+      },
+      "name": "meta.expression.group.scm",
+      "patterns": [
+        { "include": "#expression" }
+      ]
+    },
+    "bracket-expression": {
+      "begin": "\\[",
+      "end": "\\]",
+      "beginCaptures": {
+        "0": { "name": "punctuation.section.brackets.begin.scm" }
+      },
+      "endCaptures": {
+        "0": { "name": "punctuation.section.brackets.end.scm" }
+      },
+      "name": "meta.expression.alternative.scm",
+      "patterns": [
+        { "include": "#expression" }
+      ]
+    },
+    "missing-keyword": {
+      "match": "\\bMISSING\\b",
+      "name": "keyword.control.missing.scm"
+    },
+    "wildcard": {
+      "match": "\\b_\\b",
+      "name": "constant.language.wildcard.scm"
+    },
+    "anchor": {
+      "match": "(?<!\\w)\\.(?!\\w)",
+      "name": "keyword.operator.anchor.scm"
+    },
+    "capture": {
+      "match": "(@)([a-zA-Z_][a-zA-Z0-9_.]*)",
+      "captures": {
+        "1": { "name": "punctuation.definition.capture.scm" },
+        "2": { "name": "entity.name.type.capture.scm" }
+      }
+    },
+    "quantifier": {
+      "match": "[?*+]",
+      "name": "keyword.operator.quantifier.scm"
+    },
+    "negated-field": {
+      "match": "(!)([a-zA-Z_][a-zA-Z0-9_-]*)",
+      "captures": {
+        "1": { "name": "keyword.operator.negation.scm" },
+        "2": { "name": "variable.other.property.scm" }
+      }
+    },
+    "field": {
+      "match": "([a-zA-Z_][a-zA-Z0-9_-]*)(:)",
+      "captures": {
+        "1": { "name": "variable.other.member.scm" },
+        "2": { "name": "punctuation.separator.field.scm" }
+      }
+    },
+    "node": {
+      "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+      "name": "variable.other.node.scm"
+    }
+  }
 }

--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -10,24 +10,25 @@
   "repository": {
     "expression": {
       "patterns": [
-        { "include": "#comment-inherits" },
-        { "include": "#comment-extends" },
-        { "include": "#comment-format-ignore" },
-        { "include": "#comment" },
-        { "include": "#regex-predicate-call" },
-        { "include": "#set-predicate-call" },
-        { "include": "#predicate-call" },
-        { "include": "#paren-expression" },
-        { "include": "#bracket-expression" },
-        { "include": "#string" },
-        { "include": "#missing-keyword" },
-        { "include": "#wildcard" },
         { "include": "#anchor" },
         { "include": "#capture" },
-        { "include": "#quantifier" },
-        { "include": "#negated-field" },
+        { "include": "#comment" },
+        { "include": "#comment-extends" },
+        { "include": "#comment-format-ignore" },
+        { "include": "#comment-inherits" },
+        { "include": "#expression-bracket" },
+        { "include": "#expression-paren" },
         { "include": "#field" },
-        { "include": "#node" }
+        { "include": "#field-negated" },
+        { "include": "#keyword-error" },
+        { "include": "#keyword-missing" },
+        { "include": "#node" },
+        { "include": "#predicate-call" },
+        { "include": "#predicate-regex" },
+        { "include": "#predicate-set" },
+        { "include": "#quantifier" },
+        { "include": "#string" },
+        { "include": "#wildcard" }
       ]
     },
     "comment-inherits": {
@@ -82,7 +83,7 @@
       "match": "\\\\.",
       "name": "constant.character.escape.scm"
     },
-    "regex-predicate-call": {
+    "predicate-regex": {
       "begin": "(\\()\\s*(#)((?:not-)?(?:match|vim-match|lua-match|gsub)\\??)",
       "beginCaptures": {
         "1": { "name": "punctuation.section.parens.begin.scm" },
@@ -98,7 +99,7 @@
         { "include": "#regex-string" }
       ]
     },
-    "set-predicate-call": {
+    "predicate-set": {
       "begin": "(\\()\\s*(#)(set!)",
       "beginCaptures": {
         "1": { "name": "punctuation.section.parens.begin.scm" },
@@ -147,7 +148,7 @@
       "match": "[a-zA-Z_][a-zA-Z0-9_-]*",
       "name": "variable.parameter.scm"
     },
-    "paren-expression": {
+    "expression-paren": {
       "begin": "\\(",
       "end": "\\)",
       "beginCaptures": {
@@ -161,7 +162,7 @@
         { "include": "#expression" }
       ]
     },
-    "bracket-expression": {
+    "expression-bracket": {
       "begin": "\\[",
       "end": "\\]",
       "beginCaptures": {
@@ -175,9 +176,13 @@
         { "include": "#expression" }
       ]
     },
-    "missing-keyword": {
+    "keyword-missing": {
       "match": "\\bMISSING\\b",
       "name": "keyword.control.missing.scm"
+    },
+    "keyword-error": {
+      "match": "\\bERROR\\b",
+      "name": "keyword.control.error.scm"
     },
     "wildcard": {
       "match": "\\b_\\b",
@@ -198,7 +203,7 @@
       "match": "[?*+]",
       "name": "keyword.operator.quantifier.scm"
     },
-    "negated-field": {
+    "field-negated": {
       "match": "(!)([a-zA-Z_][a-zA-Z0-9_-]*)",
       "captures": {
         "1": { "name": "keyword.operator.negation.scm" },

--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -1,6 +1,7 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
 	"name": "Tree-sitter Query",
+	"scopeName": "source.scm",
 	"patterns": [
 		{
 			"include": "#expression"
@@ -9,100 +10,217 @@
 	"repository": {
 		"expression": {
 			"patterns": [
-				{
-					"include": "#comment"
-				},
-				{
-					"include": "#field"
-				},
-				{
-					"include": "#capture"
-				},
-				{
-					"include": "#node"
-				},
-				{
-					"include": "#parent-expression"
-				},
-				{
-					"include": "#bracket-expression"
-				}
+				{ "include": "#comment-inherits" },
+				{ "include": "#comment-extends" },
+				{ "include": "#comment-format-ignore" },
+				{ "include": "#comment" },
+				{ "include": "#regex-predicate-call" },
+				{ "include": "#set-predicate-call" },
+				{ "include": "#predicate-call" },
+				{ "include": "#paren-expression" },
+				{ "include": "#bracket-expression" },
+				{ "include": "#string" },
+				{ "include": "#missing-keyword" },
+				{ "include": "#wildcard" },
+				{ "include": "#anchor" },
+				{ "include": "#capture" },
+				{ "include": "#quantifier" },
+				{ "include": "#negated-field" },
+				{ "include": "#field" },
+				{ "include": "#node" }
 			]
 		},
+		"comment-inherits": {
+			"match": "^\\s*(;+\\s*inherits\\s*:.*)$",
+			"captures": {
+				"1": { "name": "keyword.control.import.scm" }
+			}
+		},
+		"comment-extends": {
+			"match": "^\\s*(;+\\s*extends\\s*)$",
+			"captures": {
+				"1": { "name": "keyword.control.directive.scm" }
+			}
+		},
+		"comment-format-ignore": {
+			"match": "^\\s*(;+\\s*format-ignore\\s*)$",
+			"captures": {
+				"1": { "name": "keyword.control.directive.scm" }
+			}
+		},
 		"comment": {
-			"begin": ";;",
+			"begin": ";",
+			"end": "$",
+			"name": "comment.line.semicolon.scm",
 			"beginCaptures": {
-				"0": {
-					"name": "comment.line.scm"
-				}
+				"0": { "name": "punctuation.definition.comment.scm" }
+			}
+		},
+		"string": {
+			"begin": "\"",
+			"end": "\"",
+			"name": "string.quoted.double.scm",
+			"beginCaptures": {
+				"0": { "name": "punctuation.definition.string.begin.scm" }
 			},
-			"end": "\\n",
-			"name": "comment.line.scm"
+			"endCaptures": {
+				"0": { "name": "punctuation.definition.string.end.scm" }
+			},
+			"patterns": [
+				{ "include": "#escape-sequence" }
+			]
+		},
+		"regex-string": {
+			"begin": "\"",
+			"end": "\"",
+			"name": "string.regexp.scm",
+			"beginCaptures": {
+				"0": { "name": "punctuation.definition.string.begin.scm" }
+			},
+			"endCaptures": {
+				"0": { "name": "punctuation.definition.string.end.scm" }
+			},
+			"patterns": [
+				{ "include": "#escape-sequence" }
+			]
+		},
+		"escape-sequence": {
+			"match": "\\\\(.|$)",
+			"name": "constant.character.escape.scm"
+		},
+		"regex-predicate-call": {
+			"begin": "(\\()\\s*(#)((?:not-)?(?:match|vim-match|lua-match|gsub)\\??)",
+			"beginCaptures": {
+				"1": { "name": "punctuation.section.parens.begin.scm" },
+				"2": { "name": "punctuation.definition.predicate.scm" },
+				"3": { "name": "entity.name.function.predicate.scm" }
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": { "name": "punctuation.section.parens.end.scm" }
+			},
+			"patterns": [
+				{ "include": "#capture" },
+				{ "include": "#regex-string" }
+			]
+		},
+		"set-predicate-call": {
+			"begin": "(\\()\\s*(#)(set!)",
+			"beginCaptures": {
+				"1": { "name": "punctuation.section.parens.begin.scm" },
+				"2": { "name": "punctuation.definition.predicate.scm" },
+				"3": { "name": "entity.name.function.predicate.scm" }
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": { "name": "punctuation.section.parens.end.scm" }
+			},
+			"patterns": [
+				{ "include": "#capture" },
+				{ "include": "#string" },
+				{ "include": "#predicate-number" },
+				{ "include": "#predicate-property" }
+			]
+		},
+		"predicate-call": {
+			"begin": "(\\()\\s*(#)([a-zA-Z_][a-zA-Z0-9_-]*)([?!]?)",
+			"beginCaptures": {
+				"1": { "name": "punctuation.section.parens.begin.scm" },
+				"2": { "name": "punctuation.definition.predicate.scm" },
+				"3": { "name": "entity.name.function.predicate.scm" },
+				"4": { "name": "punctuation.definition.predicate-type.scm" }
+			},
+			"end": "\\)",
+			"endCaptures": {
+				"0": { "name": "punctuation.section.parens.end.scm" }
+			},
+			"patterns": [
+				{ "include": "#capture" },
+				{ "include": "#string" },
+				{ "include": "#predicate-number" },
+				{ "include": "#predicate-identifier" }
+			]
+		},
+		"predicate-number": {
+			"match": "(?<!\\w)[-+]?[0-9]+(?:\\.[0-9]+)?(?!\\w)",
+			"name": "constant.numeric.scm"
+		},
+		"predicate-property": {
+			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+			"name": "variable.other.property.scm"
+		},
+		"predicate-identifier": {
+			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+			"name": "variable.parameter.scm"
 		},
 		"paren-expression": {
 			"begin": "\\(",
 			"end": "\\)",
 			"beginCaptures": {
-				"0": {
-					"name": "punctuation.paren.open"
-				}
+				"0": { "name": "punctuation.section.parens.begin.scm" }
 			},
 			"endCaptures": {
-				"0": {
-					"name": "punctuation.paren.close"
-				}
+				"0": { "name": "punctuation.section.parens.end.scm" }
 			},
-			"name": "expression.group",
+			"name": "meta.expression.group.scm",
 			"patterns": [
-				{
-					"include": "#expression"
-				}
+				{ "include": "#expression" }
 			]
 		},
 		"bracket-expression": {
 			"begin": "\\[",
 			"end": "\\]",
 			"beginCaptures": {
-				"0": {
-					"name": "punctuation.paren.open"
-				}
+				"0": { "name": "punctuation.section.brackets.begin.scm" }
 			},
 			"endCaptures": {
-				"0": {
-					"name": "punctuation.paren.close"
-				}
+				"0": { "name": "punctuation.section.brackets.end.scm" }
 			},
-			"name": "expression.group",
+			"name": "meta.expression.alternative.scm",
 			"patterns": [
-				{
-					"include": "#expression"
-				}
+				{ "include": "#expression" }
 			]
 		},
-		"field": {
-			"patterns": [
-				{
-					"name": "entity.name.scm",
-					"match": "[a-zA-Z_]+:"
-				}
-			]
+		"missing-keyword": {
+			"match": "\\bMISSING\\b",
+			"name": "keyword.control.missing.scm"
+		},
+		"wildcard": {
+			"match": "\\b_\\b",
+			"name": "constant.language.wildcard.scm"
+		},
+		"anchor": {
+			"match": "(?<!\\w)\\.(?!\\w)",
+			"name": "keyword.operator.anchor.scm"
 		},
 		"capture": {
-			"patterns": [
-				{
-					"name": "variable.other.readwrite.scm",
-					"match": "\\@[a-zA-Z_.]+"
-				}
-			]
+			"match": "(@)([a-zA-Z_][a-zA-Z0-9_.]*)",
+			"captures": {
+				"1": { "name": "punctuation.definition.capture.scm" },
+				"2": { "name": "entity.name.type.capture.scm" }
+			}
+		},
+		"quantifier": {
+			"match": "[?*+]",
+			"name": "keyword.operator.quantifier.scm"
+		},
+		"negated-field": {
+			"match": "(!)([a-zA-Z_][a-zA-Z0-9_-]*)",
+			"captures": {
+				"1": { "name": "keyword.operator.negation.scm" },
+				"2": { "name": "variable.other.property.scm" }
+			}
+		},
+		"field": {
+			"match": "([a-zA-Z_][a-zA-Z0-9_-]*)(:)",
+			"captures": {
+				"1": { "name": "variable.other.member.scm" },
+				"2": { "name": "punctuation.separator.field.scm" }
+			}
 		},
 		"node": {
-			"patterns": [
-				{
-					"name": "node.scm",
-					"match": "[a-zA-Z_]+"
-				}
-			]
+			"match": "[a-zA-Z_][a-zA-Z0-9_-]*",
+			"name": "variable.other.node.scm"
 		}
-	},
-	"scopeName": "source.scm"
+	}
 }

--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -9,26 +9,27 @@
   ],
   "repository": {
     "expression": {
+      "comment": "Ordered specific-before-general. Do not alphabetize: e.g. `#comment` matches `;` and would swallow the `;+ inherits:` directive comments",
       "patterns": [
-        { "include": "#anchor" },
-        { "include": "#capture" },
-        { "include": "#comment" },
+        { "include": "#comment-inherits" },
         { "include": "#comment-extends" },
         { "include": "#comment-format-ignore" },
-        { "include": "#comment-inherits" },
-        { "include": "#expression-bracket" },
-        { "include": "#expression-paren" },
-        { "include": "#field" },
-        { "include": "#field-negated" },
-        { "include": "#keyword-error" },
-        { "include": "#keyword-missing" },
-        { "include": "#node" },
-        { "include": "#predicate-call" },
+        { "include": "#comment" },
         { "include": "#predicate-regex" },
         { "include": "#predicate-set" },
-        { "include": "#quantifier" },
+        { "include": "#predicate-call" },
+        { "include": "#expression-paren" },
+        { "include": "#expression-bracket" },
         { "include": "#string" },
-        { "include": "#wildcard" }
+        { "include": "#capture" },
+        { "include": "#anchor" },
+        { "include": "#quantifier" },
+        { "include": "#field-negated" },
+        { "include": "#field" },
+        { "include": "#keyword-missing" },
+        { "include": "#keyword-error" },
+        { "include": "#wildcard" },
+        { "include": "#node" }
       ]
     },
     "comment-inherits": {

--- a/syntaxes/scm.tmLanguage.json
+++ b/syntaxes/scm.tmLanguage.json
@@ -31,26 +31,20 @@
       ]
     },
     "comment-inherits": {
-      "match": "^\\s*(;+\\s*inherits\\s*:.*)$",
-      "captures": {
-        "1": { "name": "keyword.control.import.scm" }
-      }
+      "match": "^[ \\t]*;+[ \\t]*inherits[ \\t]*:[^\\n]*$",
+      "name": "keyword.control.import.scm"
     },
     "comment-extends": {
-      "match": "^\\s*(;+\\s*extends\\s*)$",
-      "captures": {
-        "1": { "name": "keyword.control.directive.scm" }
-      }
+      "match": "^[ \\t]*;+[ \\t]*extends[ \\t]*$",
+      "name": "keyword.control.directive.scm"
     },
     "comment-format-ignore": {
-      "match": "^\\s*(;+\\s*format-ignore\\s*)$",
-      "captures": {
-        "1": { "name": "keyword.control.directive.scm" }
-      }
+      "match": "^[ \\t]*;+[ \\t]*format-ignore[ \\t]*$",
+      "name": "keyword.control.directive.scm"
     },
     "comment": {
       "begin": ";",
-      "end": "$",
+      "end": "(?=\\n)",
       "name": "comment.line.semicolon.scm",
       "beginCaptures": {
         "0": { "name": "punctuation.definition.comment.scm" }
@@ -85,7 +79,7 @@
       ]
     },
     "escape-sequence": {
-      "match": "\\\\(.|$)",
+      "match": "\\\\.",
       "name": "constant.character.escape.scm"
     },
     "regex-predicate-call": {


### PR DESCRIPTION
## Fixes:
  * comments now [match single `;`](https://github.com/mkatychev/vscode-tree-sitter-query/blob/a034c90e979fd0cc16ff986b892d05151f6e1214/syntaxes/scm.tmLanguage.json#L51-L58) (any amount of leading semicolons denote a comment in Tree-sitter query)
  * bracket/parentheses scopes renamed to standard `punctuation.section.*.begin`/end.scm for [better theme compatibility](https://macromates.com/manual/en/language_grammars#rule_keys):
    https://github.com/jrieken/vscode-tree-sitter-query/blob/a034c90e979fd0cc16ff986b892d05151f6e1214/syntaxes/scm.tmLanguage.json#L156-L182

## Additions:
* dedicated patterns for special comment directives:
  * `; inherits:`
  * `; extends`
  * `; format-ignore`
* added [`string.regexp`][string-regexp] scope on the regex argument for `#match?` & `#gsub` to match github.com/tree-sitter-grammars/tree-sitter-query:
  https://github.com/tree-sitter-grammars/tree-sitter-query/blob/master/queries/query/highlights.scm#L94-L102
* predicates/directive parsed as scoped calls (`#predicate?`/`#directive!`) with the prefix, `?`/`!` separately scoped
* captures split into `@` + identifier (type scope)
* separate scopes for:
  * negated fields: `!field`
  * fields: `name:`
  * quantifiers: `?`, `*`, `+`
  * anchors: `.`
  * wildcards: `(_)`
  * the `MISSING` keyword
  

NOTE: grouped conditional expression directives into predicates to separate them from comment predicates

[string-regexp]: https://macromates.com/manual/en/language_grammars#rule_keys:~:text=evaluated%E2%80%9D:%20%60date%60%2C%20$%28pwd%29%2E-,regexp%20%E2%80%94%20regular%20expressions,-:%20/%28%5Cw+%29/%2E
